### PR TITLE
Fix bower.json

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "requirejs": "~2.1.11",
     "almond": "~0.2.9",
-    "famous-polyfills": "git@github.com:Famous/polyfills.git#0.1.1",
-    "famous": "git@github.com:Famous/famous.git#v0_1_1"
+    "famous-polyfills": "git+https://github.com/Famous/polyfills.git#0.1.1",
+    "famous": "git+https://github.com/Famous/famous.git#flat0.1.1"
   },
   "scripts": {
     "postinstall": "grunt bower"


### PR DESCRIPTION
Updating to use the git+https protocol and target the tag for famous instead of the branch.  I think this is what you meant and it fixes my `bower install`.
