### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This will create:
         
         .bowerrc
         .editorconfig
-        .edlint.json
+        .eslint.json
         .jscs.json
         
         app/index.html


### PR DESCRIPTION
Minor change: `.edlint.json` -> `.eslint.json`

Before:

```
This will create:

        README.md
        Gruntfile.js
        bower.json
        package.json

        .bowerrc
        .editorconfig
        .edlint.json
        .jscs.json

        app/index.html
        app/src/main.js
        app/src/requireConfig.js
        app/src/content/images/famous_symbol_transparent.png
        app/src/styles/app.css
```

After:

```
This will create:

        README.md
        Gruntfile.js
        bower.json
        package.json

        .bowerrc
        .editorconfig
        .eslint.json
        .jscs.json

        app/index.html
        app/src/main.js
        app/src/requireConfig.js
        app/src/content/images/famous_symbol_transparent.png
        app/src/styles/app.css
```
