### PR TITLE
Exclude logs

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -9,6 +9,10 @@ Thumbs.db
 ##############
 node_modules
 
+# Logs #
+########
+*.log
+
 # Project Files #
 #################
 dist


### PR DESCRIPTION
npm often creates a `npm-debug.log` if a npm command fails. Usually these logs should be ignored.
